### PR TITLE
Allow cleartext communication with mocky.io

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/AppTheme">
 
         <activity android:name=".ui.splash.SplashActivity">

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">www.mocky.io</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
Changing `targetSdkVersion` to 28 has introduced a side effect where clear text communication is no longer allowed.
When I run the app with a 28 emulator I get an error
` <-- HTTP FAILED: java.net.UnknownServiceException: CLEARTEXT communication to www.mocky.io not permitted by network security policy`

The easy solution would be to change the `http://www.mocky.io/v2` endpoint to https. However their SSL configuration is bad and SSL requests to mocky.io get bounced.
They have an issue regarding this here: https://github.com/julien-lafont/Mocky/issues/35
Also it is evident when scanning them with this tool: https://www.sslshopper.com/ssl-checker.html#hostname=https://www.mocky.io/

This PR allows cleartext communication on 28 as described in this SO answer: https://stackoverflow.com/a/50834600/1803821