### PR TITLE
Prevent LiveData exposure to UI. Binding Livedata to recyclerview

### DIFF
--- a/app/src/main/java/com/mindorks/framework/mvvm/ui/base/BaseFragment.java
+++ b/app/src/main/java/com/mindorks/framework/mvvm/ui/base/BaseFragment.java
@@ -96,6 +96,7 @@ public abstract class BaseFragment<T extends ViewDataBinding, V extends BaseView
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         mViewDataBinding.setVariable(getBindingVariable(), mViewModel);
+        mViewDataBinding.setLifecycleOwner(this);
         mViewDataBinding.executePendingBindings();
     }
 

--- a/app/src/main/java/com/mindorks/framework/mvvm/ui/feed/blogs/BlogFragment.java
+++ b/app/src/main/java/com/mindorks/framework/mvvm/ui/feed/blogs/BlogFragment.java
@@ -93,7 +93,6 @@ public class BlogFragment extends BaseFragment<FragmentBlogBinding, BlogViewMode
         super.onViewCreated(view, savedInstanceState);
         mFragmentBlogBinding = getViewDataBinding();
         setUp();
-        subscribeToLiveData();
     }
 
     @Override
@@ -106,9 +105,5 @@ public class BlogFragment extends BaseFragment<FragmentBlogBinding, BlogViewMode
         mFragmentBlogBinding.blogRecyclerView.setLayoutManager(mLayoutManager);
         mFragmentBlogBinding.blogRecyclerView.setItemAnimator(new DefaultItemAnimator());
         mFragmentBlogBinding.blogRecyclerView.setAdapter(mBlogAdapter);
-    }
-
-    private void subscribeToLiveData() {
-        mBlogViewModel.getBlogListLiveData().observe(this, blogs -> mBlogViewModel.addBlogItemsToList(blogs));
     }
 }

--- a/app/src/main/java/com/mindorks/framework/mvvm/ui/feed/blogs/BlogViewModel.java
+++ b/app/src/main/java/com/mindorks/framework/mvvm/ui/feed/blogs/BlogViewModel.java
@@ -16,6 +16,7 @@
 
 package com.mindorks.framework.mvvm.ui.feed.blogs;
 
+import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
 import android.databinding.ObservableArrayList;
 import android.databinding.ObservableList;
@@ -31,8 +32,6 @@ import java.util.List;
 
 public class BlogViewModel extends BaseViewModel<BlogNavigator> {
 
-    public final ObservableList<BlogResponse.Blog> blogObservableArrayList = new ObservableArrayList<>();
-
     private final MutableLiveData<List<BlogResponse.Blog>> blogListLiveData;
 
     public BlogViewModel(DataManager dataManager,
@@ -40,11 +39,6 @@ public class BlogViewModel extends BaseViewModel<BlogNavigator> {
         super(dataManager, schedulerProvider);
         blogListLiveData = new MutableLiveData<>();
         fetchBlogs();
-    }
-
-    public void addBlogItemsToList(List<BlogResponse.Blog> blogs) {
-        blogObservableArrayList.clear();
-        blogObservableArrayList.addAll(blogs);
     }
 
     public void fetchBlogs() {
@@ -64,11 +58,7 @@ public class BlogViewModel extends BaseViewModel<BlogNavigator> {
                 }));
     }
 
-    public MutableLiveData<List<BlogResponse.Blog>> getBlogListLiveData() {
+    public LiveData<List<BlogResponse.Blog>> getBlogListLiveData() {
         return blogListLiveData;
-    }
-
-    public ObservableList<BlogResponse.Blog> getBlogObservableList() {
-        return blogObservableArrayList;
     }
 }

--- a/app/src/main/java/com/mindorks/framework/mvvm/ui/feed/opensource/OpenSourceFragment.java
+++ b/app/src/main/java/com/mindorks/framework/mvvm/ui/feed/opensource/OpenSourceFragment.java
@@ -92,7 +92,6 @@ public class OpenSourceFragment extends BaseFragment<FragmentOpenSourceBinding, 
         super.onViewCreated(view, savedInstanceState);
         mFragmentOpenSourceBinding = getViewDataBinding();
         setUp();
-        subscribeToLiveData();
     }
 
     private void setUp() {
@@ -100,10 +99,5 @@ public class OpenSourceFragment extends BaseFragment<FragmentOpenSourceBinding, 
         mFragmentOpenSourceBinding.openSourceRecyclerView.setLayoutManager(mLayoutManager);
         mFragmentOpenSourceBinding.openSourceRecyclerView.setItemAnimator(new DefaultItemAnimator());
         mFragmentOpenSourceBinding.openSourceRecyclerView.setAdapter(mOpenSourceAdapter);
-    }
-
-    private void subscribeToLiveData() {
-        mOpenSourceViewModel.getOpenSourceRepos().observe(this,
-                openSourceItemViewModels -> mOpenSourceViewModel.addOpenSourceItemsToList(openSourceItemViewModels));
     }
 }

--- a/app/src/main/java/com/mindorks/framework/mvvm/ui/feed/opensource/OpenSourceViewModel.java
+++ b/app/src/main/java/com/mindorks/framework/mvvm/ui/feed/opensource/OpenSourceViewModel.java
@@ -16,6 +16,7 @@
 
 package com.mindorks.framework.mvvm.ui.feed.opensource;
 
+import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
 import android.databinding.ObservableArrayList;
 import android.databinding.ObservableList;
@@ -32,8 +33,6 @@ import java.util.List;
 
 public class OpenSourceViewModel extends BaseViewModel<OpenSourceNavigator> {
 
-    private final ObservableList<OpenSourceItemViewModel> openSourceItemViewModels = new ObservableArrayList<>();
-
     private final MutableLiveData<List<OpenSourceItemViewModel>> openSourceItemsLiveData;
 
     public OpenSourceViewModel(DataManager dataManager,
@@ -41,11 +40,6 @@ public class OpenSourceViewModel extends BaseViewModel<OpenSourceNavigator> {
         super(dataManager, schedulerProvider);
         openSourceItemsLiveData = new MutableLiveData<>();
         fetchRepos();
-    }
-
-    public void addOpenSourceItemsToList(List<OpenSourceItemViewModel> openSourceItems) {
-        openSourceItemViewModels.clear();
-        openSourceItemViewModels.addAll(openSourceItems);
     }
 
     public void fetchRepos() {
@@ -65,11 +59,7 @@ public class OpenSourceViewModel extends BaseViewModel<OpenSourceNavigator> {
                 }));
     }
 
-    public ObservableList<OpenSourceItemViewModel> getOpenSourceItemViewModels() {
-        return openSourceItemViewModels;
-    }
-
-    public MutableLiveData<List<OpenSourceItemViewModel>> getOpenSourceRepos() {
+    public LiveData<List<OpenSourceItemViewModel>> getOpenSourceItemsLiveData() {
         return openSourceItemsLiveData;
     }
 

--- a/app/src/main/java/com/mindorks/framework/mvvm/ui/main/MainViewModel.java
+++ b/app/src/main/java/com/mindorks/framework/mvvm/ui/main/MainViewModel.java
@@ -16,6 +16,7 @@
 
 package com.mindorks.framework.mvvm.ui.main;
 
+import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
 import android.databinding.ObservableArrayList;
 import android.databinding.ObservableField;
@@ -63,7 +64,7 @@ public class MainViewModel extends BaseViewModel<MainNavigator> {
         return appVersion;
     }
 
-    public MutableLiveData<List<QuestionCardData>> getQuestionCardData() {
+    public LiveData<List<QuestionCardData>> getQuestionCardData() {
         return questionCardData;
     }
 

--- a/app/src/main/res/layout/fragment_blog.xml
+++ b/app/src/main/res/layout/fragment_blog.xml
@@ -41,7 +41,7 @@
                 android:id="@+id/blogRecyclerView"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                app:adapter="@{viewModel.blogObservableArrayList}"
+                app:adapter="@{viewModel.blogListLiveData}"
                 tools:listitem="@layout/item_blog_view" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_open_source.xml
+++ b/app/src/main/res/layout/fragment_open_source.xml
@@ -41,7 +41,7 @@
                 android:id="@+id/openSourceRecyclerView"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                app:adapter="@{viewModel.openSourceItemViewModels}"
+                app:adapter="@{viewModel.openSourceItemsLiveData}"
                 tools:listitem="@layout/item_blog_view" />
 
         </LinearLayout>


### PR DESCRIPTION
 - Views - should not be able to update LiveData and thus their own state because that’s the 
    responsibility of ViewModels. Views should be able to only observe LiveData.
- Setting the LifecycleOwner that should be used for observing changes of
   LiveData in this binding. We do not need to maintain an  observableArrayList.
- These changes have been done in blog and opensource fragments for a start. 